### PR TITLE
Fix issue with new atom workspace api

### DIFF
--- a/lib/language-rspec.coffee
+++ b/lib/language-rspec.coffee
@@ -2,10 +2,9 @@
 
 module.exports =
   activate: (state) ->
-    atom.workspaceView.eachEditorView (editorView) =>
-      editor = editorView.getEditor()
+    atom.workspace.observeTextEditors (editor) =>
       return unless @_isRspecFile(editor.getPath())
-      rspecGrammar = atom.syntax.grammarForScopeName 'source.ruby.rspec'
+      rspecGrammar = atom.grammars.grammarForScopeName 'source.ruby.rspec'
       return unless rspecGrammar?
       editor.setGrammar rspecGrammar
 


### PR DESCRIPTION
```
atom.workspaceView is no longer available. In most cases you will not need the view. See the Workspace docs for alternatives: https://atom.io/docs/api/latest/Workspace. If you do need the view, please use atom.views.getView(atom.workspace), which returns an HTMLElement.

Called 1 timeCreate Issue on language-rspec repo
Atom.Object.defineProperty.get - /Applications/Atom.app/Contents/Resources/app/src/atom.js:53:11
Object.activate - /Users/ryansobol/.atom/packages/language-rspec/lib/language-rspec.coffee:5:9
```