### PR TITLE
Add support for "RSpec.describe" and others.

### DIFF
--- a/grammars/rspec.cson
+++ b/grammars/rspec.cson
@@ -21,9 +21,11 @@
 ]
 'repository':
   'behaviour':
-    'begin': '^\\s*(describe|context|feature)\\b'
+    'begin': '^(RSpec)?(?:\\.|\\s*)(describe|context|feature)\\b'
     'beginCaptures':
       '1':
+        'name': 'support.class.ruby'
+      '2':
         'name': 'keyword.other.rspec.behaviour'
     'end': '\\b(do)\\s*$'
     'endCaptures':


### PR DESCRIPTION
This is probably not the best way to do it but it prevents duplication and adds support for `RSpec.describe` which is the new RSpec 3 way of doing things (even if the Object.describe) is still supported.