### PR TITLE
Fix deprecation warnings in Atom Beta 1.13

### DIFF
--- a/lib/language-rspec.coffee
+++ b/lib/language-rspec.coffee
@@ -13,5 +13,6 @@ module.exports =
   serialize: ->
 
   _isRspecFile: (filename) ->
+    return false unless filename
     rspec_filetype = 'spec.rb'
     basename(filename).slice(-rspec_filetype.length) == rspec_filetype


### PR DESCRIPTION
When creating a new file, filename is undefined, causing basename to throw a deprecation warning.