### PR TITLE
Highlight expect and should keywords

### DIFF
--- a/grammars/rspec.cson
+++ b/grammars/rspec.cson
@@ -12,6 +12,10 @@
     'name': 'keyword.other.example.rspec'
   }
   {
+    'match': '(should_not|should)'
+    'name': 'keyword.other.example.rspec'
+  }
+  {
     'match': '(?<!\\.)\\b(before|after|around)\\b(?![?!])'
     'name': 'keyword.other.hook.rspec'
   }

--- a/grammars/rspec.cson
+++ b/grammars/rspec.cson
@@ -8,7 +8,7 @@
     'include': '#behaviour'
   }
   {
-    'match': '(?<!\\.)\\b(it|specify|example|scenario|pending|skip|xit|xspecify|xexample)\\b'
+    'match': '(?<!\\.)\\b(it|specify|example|scenario|pending|skip|xit|xspecify|xexample|expect)\\b'
     'name': 'keyword.other.example.rspec'
   }
   {

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -53,7 +53,7 @@ describe 'rspec grammar', ->
 
   it 'tokenizes keywords', ->
     keywordLists =
-      'keyword.other.example.rspec': ['it', 'specify', 'example', 'scenario', 'pending', 'skip', 'xit', 'xspecify', 'xexample', 'expect']
+      'keyword.other.example.rspec': ['it', 'specify', 'example', 'scenario', 'pending', 'skip', 'xit', 'xspecify', 'xexample', 'expect', 'should_not', 'should']
       'keyword.other.hook.rspec': ['before', 'after', 'around']
 
     for scope, list of keywordLists

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -53,7 +53,7 @@ describe 'rspec grammar', ->
 
   it 'tokenizes keywords', ->
     keywordLists =
-      'keyword.other.example.rspec': ['it', 'specify', 'example', 'scenario', 'pending', 'skip', 'xit', 'xspecify', 'xexample']
+      'keyword.other.example.rspec': ['it', 'specify', 'example', 'scenario', 'pending', 'skip', 'xit', 'xspecify', 'xexample', 'expect']
       'keyword.other.hook.rspec': ['before', 'after', 'around']
 
     for scope, list of keywordLists


### PR DESCRIPTION
I'm working on some legacy projects with a lot of `should` syntax which drives me sort of crazy because I have trouble recognizing those lazy shoulds somewhere in the specs. Highlighting it makes it much more obvious to me.

Before:

![rspec_without_expect_should_highlight](https://cloud.githubusercontent.com/assets/1815342/22775408/e3a5fac6-eeab-11e6-942a-0ad715a61ad2.png)

After:

![rspec_expect_should_highlight](https://cloud.githubusercontent.com/assets/1815342/22775409/e8d4031c-eeab-11e6-836b-cfa291e60d7d.png)

I know #31 was rejected because too colorful - I agree. If this one is still too colorful would it be possible to add custom keywords to the settings page? So everyone who wants more highlights can get them?